### PR TITLE
[Feat] 포인트 정책에 따른 사용자 제약 설정

### DIFF
--- a/src/main/java/com/umust/dobonglife/domain/coupon/controller/PromotionController.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/controller/PromotionController.java
@@ -22,7 +22,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @Tag(name = "프로모션 API", description = "프로모션 관련 API")
-@SecurityRequirement(name = "BearerAuth")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/promotion")

--- a/src/main/java/com/umust/dobonglife/domain/coupon/controller/PromotionController.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/controller/PromotionController.java
@@ -36,9 +36,10 @@ public class PromotionController {
             description = "요청에 성공하였습니다."
     )
     @GetMapping
-    public BaseResponse<CursorResponse<PromotionItem>> getPromotion(@RequestParam(required = false) Long lastId,
-                                                        @RequestParam(defaultValue = "2") int size){
-        CursorResponse<PromotionItem> response = promotionService.getPromotion(lastId, size);
+    public BaseResponse<PromotionGetResponse> getPromotion(@CurrentUserId Long userId,
+                                       @RequestParam(required = false) Long lastId,
+                                       @RequestParam(defaultValue = "2") int size){
+        PromotionGetResponse response = promotionService.getPromotionWithBlocked(userId, lastId, size);
         return BaseResponse.ok(response);
     }
 

--- a/src/main/java/com/umust/dobonglife/domain/coupon/controller/dto/request/PromotionRegisterRequest.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/controller/dto/request/PromotionRegisterRequest.java
@@ -6,9 +6,7 @@ import java.util.List;
 public record PromotionRegisterRequest(
         String couponName,
         String couponDescription,
-        String categoryId,
-        String imageUrls, // TODO: 프리셋 이미지
-
+        String category,
         String discountType,
         Integer discountValue,
         Integer minPurchaseAmount,

--- a/src/main/java/com/umust/dobonglife/domain/coupon/controller/dto/request/PromotionRegisterRequest.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/controller/dto/request/PromotionRegisterRequest.java
@@ -1,12 +1,27 @@
 package com.umust.dobonglife.domain.coupon.controller.dto.request;
 
+import com.umust.dobonglife.domain.coupon.domain.constant.DiscountType;
+import com.umust.dobonglife.domain.coupon.domain.constant.PromotionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 import java.util.List;
 
 public record PromotionRegisterRequest(
         String couponName,
         String couponDescription,
+        @Schema(
+                description = "프로모션 카테고리",
+                implementation = PromotionType.class,
+                example = "RESTAURANT"
+        )
         String category,
+
+        @Schema(
+                description = "할인 유형",
+                implementation = DiscountType.class,
+                example = "PERCENT"
+        )
         String discountType,
         Integer discountValue,
         Integer minPurchaseAmount,

--- a/src/main/java/com/umust/dobonglife/domain/coupon/controller/dto/response/PromotionGetResponse.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/controller/dto/response/PromotionGetResponse.java
@@ -1,0 +1,7 @@
+package com.umust.dobonglife.domain.coupon.controller.dto.response;
+
+import com.umust.dobonglife.global.common.response.CursorResponse;
+
+public record PromotionGetResponse(boolean isBlockedUser,
+                                   CursorResponse<PromotionItem> promotions) {
+}

--- a/src/main/java/com/umust/dobonglife/domain/coupon/controller/dto/response/PromotionItem.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/controller/dto/response/PromotionItem.java
@@ -8,13 +8,19 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
-public record PromotionItem(Long promotionId, Long placeId, String category, String title,
-                            String description, List<String> imgUrls, DiscountType discountType, BigDecimal discountValue,
-                            Long point, Long minPrice, Long maxPrice, LocalDate endDate) {
+public record PromotionItem(
+        Long promotionId, Long placeId, String placeName, String operatingHour, // 추가
+        String category, String title, String description, List<String> imgUrls,
+        DiscountType discountType, BigDecimal discountValue,
+        Long point, Long minPrice, Long maxPrice, LocalDate endDate
+) {
     public static PromotionItem from(Promotion promotion) {
+        Place place = promotion.getPlace();
         return new PromotionItem(
                 promotion.getId(),
-                promotion.getPlaceId(),
+                place.getId(),
+                place.getName(),
+                place.getOperatingHour(),
                 promotion.getCategory().getDescription(),
                 promotion.getTitle(),
                 promotion.getDescription(),

--- a/src/main/java/com/umust/dobonglife/domain/coupon/domain/entity/Promotion.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/domain/entity/Promotion.java
@@ -3,6 +3,7 @@ package com.umust.dobonglife.domain.coupon.domain.entity;
 import com.umust.dobonglife.domain.coupon.controller.dto.request.PromotionRegisterRequest;
 import com.umust.dobonglife.domain.coupon.domain.constant.DiscountType;
 import com.umust.dobonglife.domain.coupon.domain.constant.PromotionType;
+import com.umust.dobonglife.domain.place.domain.entity.Place;
 import com.umust.dobonglife.global.auth.CouponCodeGenerator;
 import com.umust.dobonglife.global.error.ErrorCode;
 import com.umust.dobonglife.global.error.exception.BusinessException;
@@ -33,8 +34,9 @@ public class Promotion {
     @Column(name = "category", nullable = false)
     private PromotionType category;
 
-    @Column(name = "place_id", nullable = false)
-    private Long placeId;
+    @ManyToOne(fetch = FetchType.LAZY) // 지연 로딩 필수
+    @JoinColumn(name = "place_id", insertable = false, updatable = false)
+    private Place place;
 
     @Column(name = "title", nullable = false)
     private String title;
@@ -79,7 +81,7 @@ public class Promotion {
     private Long businessesId;
 
     @Builder
-    public Promotion(PromotionType category, Long placeId, String title, String description, List<String> imgUrls,
+    public Promotion(PromotionType category, Place place, String title, String description, List<String> imgUrls,
                      DiscountType discountType, BigDecimal discountValue, Long minPrice,
                      Long maxPrice, String code, Long point, LocalDate startDate,
                      LocalDate endDate, Long validPeriod, Long businessesId) {
@@ -87,7 +89,7 @@ public class Promotion {
         validate(discountType, discountValue, minPrice, maxPrice, code, startDate, endDate);
 
         this.category = category;
-        this.placeId = placeId;
+        this.place = place;
         this.title = title;
         this.description = description;
         this.imgUrls = (imgUrls == null || imgUrls.isEmpty()) ? Collections.singletonList(category.getImageUrl()) : imgUrls;
@@ -131,12 +133,12 @@ public class Promotion {
         }
     }
 
-    public static Promotion createPromotion(PromotionRegisterRequest dto, List<String> imgUrl, Long managerId, Long placeId) {
+    public static Promotion createPromotion(PromotionRegisterRequest dto, List<String> imgUrl, Long managerId, Place place) {
         PromotionType type = PromotionType.valueOf(dto.categoryId());
 
         return Promotion.builder()
                 .category(type)
-                .placeId(placeId)
+                .place(place)
                 .title(dto.couponName())
                 .description(dto.couponDescription())
                 .imgUrls(imgUrl.isEmpty() ? Collections.singletonList(type.getImageUrl()) : imgUrl)

--- a/src/main/java/com/umust/dobonglife/domain/coupon/domain/entity/Promotion.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/domain/entity/Promotion.java
@@ -34,8 +34,8 @@ public class Promotion {
     @Column(name = "category", nullable = false)
     private PromotionType category;
 
-    @ManyToOne(fetch = FetchType.LAZY) // 지연 로딩 필수
-    @JoinColumn(name = "place_id", insertable = false, updatable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
     private Place place;
 
     @Column(name = "title", nullable = false)
@@ -134,7 +134,7 @@ public class Promotion {
     }
 
     public static Promotion createPromotion(PromotionRegisterRequest dto, List<String> imgUrl, Long managerId, Place place) {
-        PromotionType type = PromotionType.valueOf(dto.categoryId());
+        PromotionType type = PromotionType.valueOf(dto.category());
 
         return Promotion.builder()
                 .category(type)

--- a/src/main/java/com/umust/dobonglife/domain/coupon/domain/repository/PromotionRepository.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/domain/repository/PromotionRepository.java
@@ -7,8 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PromotionRepository extends JpaRepository<Promotion, Long> {
-    @Query("SELECT c FROM Promotion c " +
-            "WHERE (:lastId IS NULL OR c.id < :lastId) " +
-            "ORDER BY c.id DESC")
-    Slice<Promotion> findPromotionNoOffset(Long lastId, Pageable pageable);
+    @Query("SELECT p FROM Promotion p " +
+            "JOIN FETCH p.place " +
+            "WHERE (:lastId IS NULL OR p.id < :lastId) " +
+            "ORDER BY p.id DESC")
+    Slice<Promotion> findPromotionWithPlaceNoOffset(Long lastId, Pageable pageable);
 }

--- a/src/main/java/com/umust/dobonglife/domain/coupon/service/PromotionService.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/service/PromotionService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,9 +48,17 @@ public class PromotionService {
         promotionRepository.save(promotion);
     }
 
+    public PromotionGetResponse getPromotionWithBlocked(Long userId, Long lastId, int size) {
+        CursorResponse<PromotionItem> cursorResponse = getPromotion(lastId, size);
+        boolean blockedUser = userService.isBlockedUser(userId);
+
+        return new PromotionGetResponse(blockedUser, cursorResponse);
+    }
+
     public CursorResponse<PromotionItem> getPromotion(Long lastId, int size) {
         Pageable pageable = PageRequest.of(0, size);
         Slice<Promotion> promotions = promotionRepository.findPromotionNoOffset(lastId, pageable);
+
         return CursorUtils.toCursorResponse(promotions, PromotionItem::from);
     }
 
@@ -61,6 +70,7 @@ public class PromotionService {
     }
 
     public UsedCouponResponse changePointToCoupon(Long userId, Long promotionId) {
+        userService.canExchangeCoupon(userId);
         Promotion promotion = promotionRepository.findById(promotionId).orElseThrow(() -> new EntityNotFoundException("[ERROR] 프로모션이 존재하지 않습니다."));
         User user = userService.findById(userId);
 
@@ -97,12 +107,5 @@ public class PromotionService {
         Promotion promotion = Promotion.createPromotion(request, imageUrls, userId, placeId);
         Promotion savedPromotion = promotionRepository.save(promotion);
         return PromotionRegisterResponse.from(savedPromotion);
-    }
-
-    private void validateManagerRole(Long userId) {
-        Role userRole = userService.getUserRole(userId);
-        if (userRole != Role.MANAGER) {
-            throw new BusinessException(ErrorCode.NOT_BUSINESS);
-        }
     }
 }

--- a/src/main/java/com/umust/dobonglife/domain/coupon/service/PromotionService.java
+++ b/src/main/java/com/umust/dobonglife/domain/coupon/service/PromotionService.java
@@ -8,6 +8,7 @@ import com.umust.dobonglife.domain.coupon.domain.entity.Promotion;
 import com.umust.dobonglife.domain.coupon.domain.repository.PromotionRepository;
 import com.umust.dobonglife.domain.coupon.controller.dto.response.*;
 import com.umust.dobonglife.domain.course.controller.dto.response.CourseSummaryResponse;
+import com.umust.dobonglife.domain.place.domain.entity.Place;
 import com.umust.dobonglife.domain.place.service.PlaceService;
 import com.umust.dobonglife.domain.point.service.PointService;
 import com.umust.dobonglife.domain.user.domain.constant.Role;
@@ -57,14 +58,14 @@ public class PromotionService {
 
     public CursorResponse<PromotionItem> getPromotion(Long lastId, int size) {
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Promotion> promotions = promotionRepository.findPromotionNoOffset(lastId, pageable);
+        Slice<Promotion> promotions = promotionRepository.findPromotionWithPlaceNoOffset(lastId, pageable);
 
         return CursorUtils.toCursorResponse(promotions, PromotionItem::from);
     }
 
     public CursorResponse<PromotionSummaryItem> getPromotionSummary(Long lastId, int size) {
         Pageable pageable = PageRequest.of(0, size);
-        Slice<Promotion> promotions = promotionRepository.findPromotionNoOffset(lastId, pageable);
+        Slice<Promotion> promotions = promotionRepository.findPromotionWithPlaceNoOffset(lastId, pageable);
 
         return CursorUtils.toCursorResponse(promotions, PromotionSummaryItem::from);
     }
@@ -104,7 +105,8 @@ public class PromotionService {
 
     @Transactional
     public PromotionRegisterResponse savePromotionWithTransaction(PromotionRegisterRequest request, List<String> imageUrls, Long userId, Long placeId) {
-        Promotion promotion = Promotion.createPromotion(request, imageUrls, userId, placeId);
+        Place place = placeService.findById(placeId);
+        Promotion promotion = Promotion.createPromotion(request, imageUrls, userId, place);
         Promotion savedPromotion = promotionRepository.save(promotion);
         return PromotionRegisterResponse.from(savedPromotion);
     }

--- a/src/main/java/com/umust/dobonglife/domain/course/controller/dto/response/CourseRegisterResponse.java
+++ b/src/main/java/com/umust/dobonglife/domain/course/controller/dto/response/CourseRegisterResponse.java
@@ -4,16 +4,20 @@ import com.umust.dobonglife.domain.course.domain.entity.Course;
 
 import java.time.LocalDateTime;
 
+import static com.umust.dobonglife.domain.point.domain.vo.PointPolicy.COURSE_CREATE;
+
 public record CourseRegisterResponse(
         Long courseId,
         String title,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        Long point
 ) {
     public static CourseRegisterResponse from(Course course) {
         return new CourseRegisterResponse(
                 course.getId(),
                 course.getBasicInfo().getTitle(),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                COURSE_CREATE.getPoint()
         );
     }
 }

--- a/src/main/java/com/umust/dobonglife/domain/course/service/CourseService.java
+++ b/src/main/java/com/umust/dobonglife/domain/course/service/CourseService.java
@@ -1,6 +1,5 @@
 package com.umust.dobonglife.domain.course.service;
 
-import com.umust.dobonglife.domain.course.controller.dto.response.CourseDetailResponse;
 import com.umust.dobonglife.domain.course.controller.dto.request.CoursePlanRequest;
 import com.umust.dobonglife.domain.course.controller.dto.request.UpdateCourseRequest;
 import com.umust.dobonglife.domain.course.controller.dto.response.CourseDeleteResponse;
@@ -10,14 +9,11 @@ import com.umust.dobonglife.domain.course.domain.constant.CourseTheme;
 import com.umust.dobonglife.domain.course.domain.entity.Course;
 import com.umust.dobonglife.domain.course.domain.entity.CourseDescription;
 import com.umust.dobonglife.domain.course.domain.entity.CoursePlans;
-import com.umust.dobonglife.domain.course.domain.repository.CoursePlansRepository;
 import com.umust.dobonglife.domain.course.controller.dto.request.CreateCourseRequest;
 import com.umust.dobonglife.domain.course.controller.dto.response.CourseSummaryResponse;
 import com.umust.dobonglife.domain.course.domain.repository.CourseRepository;
 import com.umust.dobonglife.domain.course.domain.vo.CourseBasicInfo;
-import com.umust.dobonglife.domain.courseLike.service.CourseLikeService;
-import com.umust.dobonglife.domain.review.controller.dto.response.ReviewSummaryResponse;
-import com.umust.dobonglife.domain.review.service.ReviewService;
+import com.umust.dobonglife.domain.point.service.PointService;
 import com.umust.dobonglife.domain.user.service.UserService;
 import com.umust.dobonglife.global.common.response.CursorUtils;
 import com.umust.dobonglife.global.error.exception.BusinessException;
@@ -39,6 +35,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.umust.dobonglife.domain.point.domain.vo.PointPolicy.COURSE_CREATE;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -46,6 +44,7 @@ public class CourseService {
     private final CourseRepository courseRepository;
     private final S3Utils s3Utils;
     private final UserService userService;
+    private final PointService pointService;
 
 
     @Transactional(readOnly = true)
@@ -114,6 +113,9 @@ public class CourseService {
                 .description(description)
                 .plans(plans)
                 .build();
+
+        pointService.earnPoint(userService.findById(userId), COURSE_CREATE.getTitle(), COURSE_CREATE.getPoint());
+        userService.updatePoint(userId, COURSE_CREATE.getPoint());
 
         return courseRepository.save(course);
     }
@@ -198,6 +200,7 @@ public class CourseService {
                 }
             }
         });
+        userService.handleDeletion(userId);
         return CourseDeleteResponse.from(courseId);
     }
 
@@ -216,7 +219,7 @@ public class CourseService {
     }
 
     @Transactional
-    public void deleteCourseReview(Long courseId, Double rating) {
+    public void deleteCourseReview(Long userId, Long courseId, Double rating) {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 Course 엔티티를 찾을 수 없습니다: " + courseId));
         course.deleteReview(rating);

--- a/src/main/java/com/umust/dobonglife/domain/place/service/PlaceService.java
+++ b/src/main/java/com/umust/dobonglife/domain/place/service/PlaceService.java
@@ -70,8 +70,7 @@ public class PlaceService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        Place place = placeRepository.findById(placeId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_NOT_FOUND));
+        Place place = findById(placeId);
 
         Optional<PlaceLike> articleLikesOptional = placeLikeRepository.findByUserIdAndPlaceId(user.getId(), place.getId());
 
@@ -103,16 +102,14 @@ public class PlaceService {
 
     @Transactional
     public void updatePlaceRatingAndCount(Long placeId, Double rating) {
-        Place place = placeRepository.findById(placeId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_NOT_FOUND));
+        Place place = findById(placeId);
         place.applyNewReview(rating);
         placeRepository.save(place);
     }
 
     @Transactional
     public void deletePlaceReview(Long placeId, Double rating) {
-        Place place = placeRepository.findById(placeId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PLACE_NOT_FOUND));
+        Place place = findById(placeId);
         place.applyDeleteReview(rating);
         placeRepository.save(place);
     }
@@ -121,5 +118,9 @@ public class PlaceService {
     public PlaceSummaryListResponse getAllPlace(Long userId) {
         List<PlaceSummaryResponse> responses = placeRepository.findPlaceSummaries(userId);
         return PlaceSummaryListResponse.from(responses);
+    }
+
+    public Place findById(Long placeId) {
+        return placeRepository.findById(placeId).orElseThrow(() -> new BusinessException(ErrorCode.PLACE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/umust/dobonglife/domain/point/domain/vo/PointPolicy.java
+++ b/src/main/java/com/umust/dobonglife/domain/point/domain/vo/PointPolicy.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum PointPolicy {
 
-    REVIEW_CREATE("리뷰 등록", 10L);
+    REVIEW_CREATE("리뷰 등록", 10L),
+    COURSE_CREATE("코스 등록", 10L);
 
     private final String title;
     private final long point;

--- a/src/main/java/com/umust/dobonglife/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umust/dobonglife/domain/review/controller/ReviewController.java
@@ -38,7 +38,7 @@ public class ReviewController {
     public BaseResponse<ReviewResponse> registerReview(@CurrentUserId Long userId,
                                                        @RequestPart("request") @Valid CreateReviewRequest request, @RequestPart(value = "imageFiles", required = false) List<MultipartFile> imageFiles){
         ReviewResponse response = reviewService.createReview(userId, request, imageFiles);
-        return BaseResponse.ok(response, SuccessCode.REVIEW_POINT_SUCCESS);
+        return BaseResponse.ok(response);
     }
 
     // 리뷰 수정하기

--- a/src/main/java/com/umust/dobonglife/domain/review/controller/dto/response/ReviewResponse.java
+++ b/src/main/java/com/umust/dobonglife/domain/review/controller/dto/response/ReviewResponse.java
@@ -1,13 +1,17 @@
 package com.umust.dobonglife.domain.review.controller.dto.response;
 import com.umust.dobonglife.domain.review.domain.entity.Review;
 
+import static com.umust.dobonglife.domain.point.domain.vo.PointPolicy.REVIEW_CREATE;
+
 public record ReviewResponse(Long reviewId,
-                             String content) {
+                             String content,
+                             Long point) {
 
     public static ReviewResponse from(Review review) {
         return new ReviewResponse(
                 review.getId(),
-                review.getContent()
+                review.getContent(),
+                REVIEW_CREATE.getPoint()
         );
     }
 }

--- a/src/main/java/com/umust/dobonglife/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umust/dobonglife/domain/review/service/ReviewService.java
@@ -89,6 +89,7 @@ public class ReviewService {
                 .build();
         reviewRepository.save(review);
         pointService.earnPoint(userService.findById(userId), REVIEW_CREATE.getTitle(), REVIEW_CREATE.getPoint());
+        userService.updatePoint(userId, REVIEW_CREATE.getPoint());
 
         return ReviewResponse.from(review);
     }
@@ -145,12 +146,13 @@ public class ReviewService {
             throw new BusinessException(ErrorCode.SECURITY_ACCESS_DENIED);
 
         if(review.getCourseId() != null){
-            courseService.deleteCourseReview(review.getCourseId(), review.getRating());
+            courseService.deleteCourseReview(userId ,review.getCourseId(), review.getRating());
         }else{
             placeService.deletePlaceReview(review.getPlaceId(), review.getRating());
         }
 
         reviewRepository.delete(review);
+        userService.handleDeletion(userId);
         return ReviewResponse.from(review);
     }
 }

--- a/src/main/java/com/umust/dobonglife/domain/user/domain/entity/User.java
+++ b/src/main/java/com/umust/dobonglife/domain/user/domain/entity/User.java
@@ -19,6 +19,9 @@ import java.time.LocalDateTime;
 @Setter
 public class User extends BaseEntity {
 
+    private static final int PENALTY_THRESHOLD = 3;
+    private static final long PENALTY_DAYS = 7;
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id", nullable = false)
     private Long id;
@@ -68,12 +71,38 @@ public class User extends BaseEntity {
     }
 
     public void handleDeletion() {
-        this.deleteCount += 1;
-
-        if (this.deleteCount >= 3) {
-            this.isBlocked = true;
-            this.blockedAt = LocalDateTime.now();
-            this.deleteCount = 0;
+        this.deleteCount++;
+        if (this.deleteCount >= PENALTY_THRESHOLD) {
+            applyPenalty();
         }
     }
+
+    private void applyPenalty() {
+        this.isBlocked = true;
+        this.blockedAt = LocalDateTime.now();
+        this.deleteCount = 0;
+    }
+
+    public boolean canExchangeCoupon() {
+        if (!this.isBlocked) {
+            return true;
+        }
+
+        if (isPenaltyExpired()) {
+            liftPenalty();
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isPenaltyExpired() {
+        return LocalDateTime.now().isAfter(this.blockedAt.plusDays(PENALTY_DAYS));
+    }
+
+    private void liftPenalty() {
+        this.isBlocked = false;
+        this.blockedAt = null;
+    }
+
 }

--- a/src/main/java/com/umust/dobonglife/domain/user/domain/entity/User.java
+++ b/src/main/java/com/umust/dobonglife/domain/user/domain/entity/User.java
@@ -62,4 +62,18 @@ public class User extends BaseEntity {
 
     @Column(nullable = true)
     private LocalDateTime blockedAt;
+
+    public void updatePoint(Long point) {
+        balance += point;
+    }
+
+    public void handleDeletion() {
+        this.deleteCount += 1;
+
+        if (this.deleteCount >= 3) {
+            this.isBlocked = true;
+            this.blockedAt = LocalDateTime.now();
+            this.deleteCount = 0;
+        }
+    }
 }

--- a/src/main/java/com/umust/dobonglife/domain/user/service/UserService.java
+++ b/src/main/java/com/umust/dobonglife/domain/user/service/UserService.java
@@ -24,6 +24,8 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import com.umust.dobonglife.domain.user.domain.entity.User;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -113,6 +115,18 @@ public class UserService {
     public Role getUserRole(Long userId) {
         User byId = findById(userId);
         return byId.getRole();
+    }
+
+    public void updatePoint(Long userId, Long point) {
+        User byId = findById(userId);
+        byId.updatePoint(point);
+    }
+
+    @Transactional
+    public void handleDeletion(Long userId) {
+        User byId = findById(userId);
+        byId.handleDeletion();
+        userRepository.save(byId);
     }
 }
 

--- a/src/main/java/com/umust/dobonglife/domain/user/service/UserService.java
+++ b/src/main/java/com/umust/dobonglife/domain/user/service/UserService.java
@@ -128,5 +128,18 @@ public class UserService {
         byId.handleDeletion();
         userRepository.save(byId);
     }
+
+    @Transactional
+    public void canExchangeCoupon(Long userId) {
+        User byId = findById(userId);
+        if(!byId.canExchangeCoupon())
+            throw new BusinessException(ErrorCode.COUPON_EXCHANGE_RESTRICTED);
+
+    }
+
+    public boolean isBlockedUser(Long userId) {
+        User byId = findById(userId);
+        return byId.isBlocked();
+    }
 }
 

--- a/src/main/java/com/umust/dobonglife/global/error/ErrorCode.java
+++ b/src/main/java/com/umust/dobonglife/global/error/ErrorCode.java
@@ -101,7 +101,9 @@ public enum ErrorCode{
     INVALID_DISCOUNT_VALUE(500, HttpStatus.BAD_REQUEST.value(), "할인 100%를 초과할 수 없습니다."),
     INVALID_COUPON_CODE(500, HttpStatus.BAD_REQUEST.value(), "쿠폰 코드는 6자리입니다."),
     INVALID_DATE_RANGE(500, HttpStatus.BAD_REQUEST.value(), "종료일보다 시작일이 빠릅니다."),
-    BUSINESS_NOT_FOUND(900, HttpStatus.NOT_FOUND.value(), "사업장을 찾을 수 없습니다.");
+    BUSINESS_NOT_FOUND(900, HttpStatus.NOT_FOUND.value(), "사업장을 찾을 수 없습니다."),
+
+    COUPON_EXCHANGE_RESTRICTED(403,HttpStatus.FORBIDDEN.value(), "리뷰 정책 위반(3회 삭제)으로 인해 쿠폰 교환이 제한되었습니다.");
 
     private final int code;
     private final int httpStatus;


### PR DESCRIPTION
## Related issue 🛠
- closed #80 

## Work Description 📝
- 포인트 정책에 따른 사용자 제약 설정 (쿠폰 교환 block)
- 프로모션 조회 시 장소이름, 운영시간 추가 = N+1 문제가 해결
- 리뷰 및 코스 등록 시 포인트 필드 반환
- 작성한 리뷰 및 코스 삭제 시 쿠폰교환 제한
- 수정된 API 테스트

## Screenshot 📸
<img width="414" height="501" alt="스크린샷 2026-01-25 오전 11 10 47" src="https://github.com/user-attachments/assets/996c45fe-8cc9-4000-be85-006a5a5e6d1e" />
<img width="811" height="421" alt="스크린샷 2026-01-26 오전 9 04 57" src="https://github.com/user-attachments/assets/8708d5b0-fcb6-4f38-867c-8b828f6bab77" />

- type enum 확인 정보는 스웨거에 올려놨으나, 혹시 찾는데 어려움이 있을까 하여 사진으로 첨부합니다.

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢
포인트 정책에 따른 사용자 제약은 Redis가 아닌 DB에 설정했습니다.
사용자 관련 정책이므로 보안이 고려되어야하고, 영구저장과 정합성이 보장되어야하기 때문입니다.
그러나, DB에 설정된 정책을 매번 조회하면 성능 저하가 우려될수 있으므로, 캐싱전략을 병행할 예정입니다. 추후 추가하겠습니다!